### PR TITLE
Support encoding options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ go-libwebp
 [![Build Status](https://travis-ci.org/harukasan/go-libwebp.svg)](https://travis-ci.org/harukasan/go-libwebp)
 [![GoDoc](https://godoc.org/github.com/harukasan/go-libwebp/webp?status.svg)](https://godoc.org/github.com/harukasan/go-libwebp/webp)
 
-A implementation of Go binding for [libwebp](https://developers.google.com/speed/webp/docs/api) written with cgo.
+A implementation of Go binding for [libwebp](https://developers.google.com/speed/webp/docs/api).
+
+## Dependencies
+
+- libwebp 0.4, 0.5
 
 ## Usage
 
@@ -63,10 +67,7 @@ func main() {
 		io.Close()
 	}()
 
-	config := webp.Config{
-		Preset:  webp.PresetDefault,
-		Quality: 90,
-	}
+	config := webp.ConfigPreset(webp.PresetDefault, 90)
 
 	// Encode into WebP
 	if err := webp.EncodeRGBA(w, img.(*image.RGBA), config); err != nil {
@@ -82,7 +83,7 @@ func main() {
 
 ## License
 
-Copyright (c) 2014 MICHII Shunsuke. All rights reserved.
+Copyright (c) 2016 MICHII Shunsuke. All rights reserved.
 
 This library is released under The BSD 2-Clause License.
 See [LICENSE](./LICENSE).

--- a/examples/encode/encode.go
+++ b/examples/encode/encode.go
@@ -20,10 +20,9 @@ func main() {
 		io.Close()
 	}()
 
-	config := webp.Config{
-		Preset:  webp.PresetDefault,
-		Quality: 90,
-		Method:  6,
+	config, err := webp.ConfigPreset(webp.PresetDefault, 90)
+	if err != nil {
+		panic(err)
 	}
 
 	// Encode into WebP

--- a/webp/encode.go
+++ b/webp/encode.go
@@ -14,6 +14,14 @@ static void free_WebPPicture(WebPPicture* webpPicture) {
 	free(webpPicture);
 }
 
+static int webPConfigLosslessPreset(WebPConfig* webpConfig, int level) {
+#if WEBP_ENCODER_ABI_VERSION < 0x203
+	return 0;
+#else
+	return WebPConfigLosslessPreset(webpConfig, level);
+#endif
+}
+
 static int getNearLossless(WebPConfig* webpConfig, int* value) {
 #if WEBP_ENCODER_ABI_VERSION < 0x206
 	return 0;
@@ -82,7 +90,7 @@ func ConfigPreset(preset Preset, quality float32) (*Config, error) {
 // compression) and 9 (slower, best compression).
 func ConfigLosslessPreset(level int) (*Config, error) {
 	c := &Config{}
-	if C.WebPConfigLosslessPreset(&c.c, C.int(level)) == 0 {
+	if C.webPConfigLosslessPreset(&c.c, C.int(level)) == 0 {
 		return nil, errors.New("failed to initialize webp config")
 	}
 	return c, nil

--- a/webp/webp.go
+++ b/webp/webp.go
@@ -21,6 +21,17 @@ const (
 	YUV420A ColorSpace = C.WEBP_YUV420A
 )
 
+// ImageHint corresponds to C.WebPImageHint.
+type ImageHint int
+
+const (
+	HintDefault ImageHint = C.WEBP_HINT_DEFAULT
+	HintPicture ImageHint = C.WEBP_HINT_PICTURE
+	HintPhoto   ImageHint = C.WEBP_HINT_PHOTO
+	HintGraph   ImageHint = C.WEBP_HINT_GRAPH
+	HintLast    ImageHint = C.WEBP_HINT_LAST
+)
+
 // Preset corresponds to C.WebPPreset.
 type Preset int
 
@@ -47,4 +58,16 @@ const (
 	SimpleFilter FilterType = iota
 	// StrongFilter (=1)
 	StrongFilter
+)
+
+// Preprocessing corresponds to preprocessing filter parameter.
+type Preprocessing int
+
+const (
+	// PreprocessingNone specifies to disable preprocessing filter.
+	PreprocessingNone = 0
+	// PreprocessingSegmentSmooth specifies segment-smooth filter.
+	PreprocessingSegmentSmooth = 1
+	//PreprocessingPseudoRandomDithering specifies pseudo-random dithering filter.
+	PreprocessingPseudoRandomDithering = 2
 )

--- a/webp/webp_test.go
+++ b/webp/webp_test.go
@@ -151,10 +151,9 @@ func TestDecodeRGBAWithScaling(t *testing.T) {
 func TestEncodeRGBA(t *testing.T) {
 	img := util.ReadPNG("yellow-rose-3.png")
 
-	config := webp.Config{
-		Preset:  webp.PresetDefault,
-		Quality: 100,
-		Method:  6,
+	config, err := webp.ConfigPreset(webp.PresetDefault, 100)
+	if err != nil {
+		t.Fatalf("got error: %v", err)
 	}
 
 	f := util.CreateFile("TestEncodeRGBA.webp")
@@ -173,10 +172,9 @@ func TestEncodeRGBA(t *testing.T) {
 func TestEncodeRGB(t *testing.T) {
 	img := util.ReadPNG("yellow-rose-3.png")
 
-	config := webp.Config{
-		Preset:  webp.PresetDefault,
-		Quality: 100,
-		Method:  6,
+	config, err := webp.ConfigPreset(webp.PresetDefault, 100)
+	if err != nil {
+		t.Fatalf("got error: %v", err)
 	}
 
 	f := util.CreateFile("TestEncodeRGB.webp")
@@ -209,10 +207,9 @@ func TestEncodeYUVA(t *testing.T) {
 		f.Close()
 	}()
 
-	config := webp.Config{
-		Preset:  webp.PresetDefault,
-		Quality: 100,
-		Method:  6,
+	config, err := webp.ConfigPreset(webp.PresetDefault, 100)
+	if err != nil {
+		t.Fatalf("got error: %v", err)
 	}
 
 	if err := webp.EncodeYUVA(w, img, config); err != nil {


### PR DESCRIPTION
This PR changes `Config` interface to support all webp encoding options.

To support some ABI versions of libwebp, the new `Config` have getter/setter functions.

