### PR TITLE
Fix typo in Config.SetLossless()

### DIFF
--- a/webp/encode.go
+++ b/webp/encode.go
@@ -140,7 +140,7 @@ func ConfigLosslessPreset(level int) (*Config, error) {
 // SetLossless sets lossless parameter that specifies whether to enable lossless
 // encoding.
 func (c *Config) SetLossless(v bool) {
-	c.c.autofilter = boolToValue(v)
+	c.c.lossless = boolToValue(v)
 }
 
 // Lossless returns lossless parameter flag whether to enable lossless encoding.


### PR DESCRIPTION
Fixed a small typo (copy paste error).

Thank you.