### PR TITLE
Fix confusing heights with widths on YUVA buffer allocation

### DIFF
--- a/webp/yuva_image.go
+++ b/webp/yuva_image.go
@@ -25,7 +25,7 @@ type YUVAImage struct {
 
 // NewYUVAImage creates and allocates image buffer.
 func NewYUVAImage(r image.Rectangle, c ColorSpace) (image *YUVAImage) {
-	yw, yh := r.Dx(), r.Dx()
+	yw, yh := r.Dx(), r.Dy()
 	cw, ch := ((r.Max.X+1)/2 - r.Min.X/2), ((r.Max.Y+1)/2 - r.Min.Y/2)
 
 	switch c {


### PR DESCRIPTION
It is confusing heights with widths.

Though this is a trivial typo, its impact is somewhat serious. It leads to a buffer overrun under certain conditions.