### PR TITLE
Add DecodeNRGBA() to fix alpha pre-multiplication confusion

### DIFF
--- a/webp/webp_test.go
+++ b/webp/webp_test.go
@@ -109,6 +109,26 @@ func TestDecodeRGBA(t *testing.T) {
 	}
 }
 
+func TestDecodeNRGBA(t *testing.T) {
+	files := []string{
+		"cosmos.webp",
+		"butterfly.webp",
+		"kinkaku.webp",
+		"yellow-rose-3.webp",
+	}
+
+	for _, file := range files {
+		data := util.ReadFile(file)
+		options := &webp.DecoderOptions{}
+
+		_, err := webp.DecodeNRGBA(data, options)
+		if err != nil {
+			t.Errorf("Got Error: %v", err)
+			return
+		}
+	}
+}
+
 func TestDecodeRGBAWithCropping(t *testing.T) {
 	data := util.ReadFile("cosmos.webp")
 	crop := image.Rect(100, 100, 300, 200)


### PR DESCRIPTION
This pull request fixes colorspace confusion between premultiplied and non-premultiplied alpha.

it seems appropreate to use `image.RGBA` with `MODE_rgbA` and `image.NRGBA` with `MODE_RGBA`.
According to libwebp's header file, with `MODE_RGBA` colorspace option it decodes to non-premultiplied RGBA. It decodes to premultiplied RGBA with `MODE_rgbA` instead.
https://github.com/webmproject/libwebp/blob/2de4b05a56e4da42d170f4af8b01327a3b4b251b/src/webp/decode.h#L137-L162
> Non-capital names (e.g.:MODE_Argb) relates to pre-multiplied RGB channels.

I made `image.RGBA` contain alpha-premultiplied colors and added a decode function variant which returns `image.NRGBA` to fix this issue.

Your feedback about the API design is welcome. The feedback about my overall approach is also OK.
